### PR TITLE
Add sonar to the main scene

### DIFF
--- a/Main.tscn
+++ b/Main.tscn
@@ -2,11 +2,15 @@
 
 [ext_resource type="PackedScene" uid="uid://b0nj2t4hiob6a" path="res://Player.tscn" id="1_odt7v"]
 [ext_resource type="PackedScene" uid="uid://lvsvp7bk6fhr" path="res://Mine.tscn" id="2_7te8d"]
+[ext_resource type="PackedScene" uid="uid://bwh133vw085xm" path="res://Sonar.tscn" id="3_xk4r6"]
 
 [node name="Node2D" type="Node2D"]
 
 [node name="Player" parent="." instance=ExtResource("1_odt7v")]
-position = Vector2(175, 220)
+position = Vector2(159, 252)
 
 [node name="Mine" parent="." instance=ExtResource("2_7te8d")]
 position = Vector2(826, 313)
+
+[node name="Sonar" parent="." instance=ExtResource("3_xk4r6")]
+position = Vector2(45, 603)

--- a/Main.tscn
+++ b/Main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=3 format=3 uid="uid://oa08cq2rxqum"]
+[gd_scene load_steps=4 format=3 uid="uid://oa08cq2rxqum"]
 
 [ext_resource type="PackedScene" uid="uid://b0nj2t4hiob6a" path="res://Player.tscn" id="1_odt7v"]
 [ext_resource type="PackedScene" uid="uid://lvsvp7bk6fhr" path="res://Mine.tscn" id="2_7te8d"]
@@ -14,3 +14,5 @@ position = Vector2(826, 313)
 
 [node name="Sonar" parent="." instance=ExtResource("3_xk4r6")]
 position = Vector2(45, 603)
+
+[connection signal="sonar_activated" from="Sonar" to="Mine" method="_on_sonar_sonar_activated"]

--- a/Obstacle.gd
+++ b/Obstacle.gd
@@ -2,6 +2,8 @@ extends Area2D
 
 @export var attack: int = 5
 
+@onready var _animation = $AnimationPlayer
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
     pass # Replace with function body.
@@ -17,3 +19,6 @@ func _on_body_entered(body):
         body.take_damage(attack)
     hide()
     pass # Replace with function body.
+
+func _on_sonar_sonar_activated():
+    _animation.play("detected")

--- a/Obstacle.tscn
+++ b/Obstacle.tscn
@@ -1,8 +1,28 @@
-[gd_scene load_steps=3 format=3 uid="uid://dc3ybroegj3yi"]
+[gd_scene load_steps=5 format=3 uid="uid://dc3ybroegj3yi"]
 
 [ext_resource type="Script" path="res://Obstacle.gd" id="1_41g1h"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_rq35x"]
+
+[sub_resource type="Animation" id="Animation_cjefq"]
+resource_name = "detected"
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Sprite2D:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.2, 0.4, 0.6, 0.8),
+"transitions": PackedFloat32Array(1, 1, 1, 1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 1), Color(0, 0.482353, 0, 1), Color(1, 1, 1, 1), Color(0, 0.482353, 0, 1), Color(1, 1, 1, 1)]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_qi4e0"]
+_data = {
+"detected": SubResource("Animation_cjefq")
+}
 
 [node name="Obstacle" type="Area2D" groups=["Enemy"]]
 position = Vector2(159, 87)
@@ -13,5 +33,10 @@ metadata/_edit_group_ = true
 shape = SubResource("CircleShape2D_rq35x")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+"": SubResource("AnimationLibrary_qi4e0")
+}
 
 [connection signal="area_entered" from="." to="." method="_on_area_entered"]

--- a/Sonar.gd
+++ b/Sonar.gd
@@ -1,0 +1,25 @@
+extends Sprite2D
+
+signal sonar_activated
+
+var isOnCooldown: bool = false
+
+@onready var _timer :Timer = $Timer
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+    _timer.timeout.connect(_reset_cooldown)
+    pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+    if Input.is_action_pressed("sonar") && not isOnCooldown:
+        isOnCooldown = true
+        _timer.start()
+        set_modulate(Color("6c6c6c"))
+        sonar_activated.emit()
+
+func _reset_cooldown():
+    isOnCooldown = false
+    set_modulate(Color("ffffff"))

--- a/Sonar.tscn
+++ b/Sonar.tscn
@@ -1,0 +1,13 @@
+[gd_scene load_steps=3 format=3 uid="uid://bwh133vw085xm"]
+
+[ext_resource type="Script" path="res://Sonar.gd" id="1_hpm43"]
+[ext_resource type="Texture2D" uid="uid://dmluj427jwapa" path="res://icon.svg" id="2_wgwb0"]
+
+[node name="Sonar" type="Sprite2D"]
+position = Vector2(261, 324)
+scale = Vector2(0.25, 0.25)
+texture = ExtResource("2_wgwb0")
+script = ExtResource("1_hpm43")
+
+[node name="Timer" type="Timer" parent="."]
+wait_time = 3.0

--- a/project.godot
+++ b/project.godot
@@ -19,6 +19,14 @@ config/icon="res://icon.svg"
 
 project/assembly_name="game jam thing"
 
+[input]
+
+sonar={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"echo":false,"script":null)
+]
+}
+
 [physics]
 
 2d/default_gravity=1.0


### PR DESCRIPTION
Shows how we could set up sonar and connect it all up.

Sonar:
- is activate by pressing SPACE
- has a 3 second cooldown
- sends a sonar_activated signal when used
- currently has a placeholder icon in the bottom left that is greyed out when on cooldown

The mine in the main scene:
- listens for the sonar
- currently flashes green when used but we can change this to toggle it's sprite or whatever

![sub_sonar](https://github.com/SStewart424/brackeys-game-jam-23/assets/34354540/4242bbd7-e407-48d0-bdd0-3ff82b1445f4)
